### PR TITLE
Add GitHub Skills activity to extracurricular activities

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub Certifications program",
+        "schedule": "Wednesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Description
Adds the GitHub Skills activity that was requested in issue #6.

## Changes Made
- Added "GitHub Skills" activity to the activities database in `src/app.py`
- Configured with:
  - **Description:** Learn practical coding and collaboration skills through GitHub Certifications program
  - **Schedule:** Wednesdays, 3:30 PM - 4:30 PM
  - **Max Participants:** 25
  - **Initial Participants:** Empty (available for signup)

## Related Issue
Closes #6 - Missing Activity: GitHub Skills

## Testing
The new activity should now be visible on the activities list and students should be able to sign up for it.